### PR TITLE
inflection_points: Add test coverage and fix

### DIFF
--- a/polliwog/polyline/inflection_points.py
+++ b/polliwog/polyline/inflection_points.py
@@ -7,6 +7,14 @@ def inflection_points(points, axis, span):
     Find the list of vertices that preceed inflection points in a curve. The curve is differentiated
     with respect to the coordinate system defined by axis and span.
 
+    Interestingly, `lambda x: 2*x + 1` should have no inflection points, but
+    almost every point on the line is detected. It's because a zero or zero
+    crossing in the second derivative is necessary but not sufficient to
+    detect an inflection point. You also need a higher derivative of odd
+    order that's non-zero. But that gets ugly to detect reliably using sparse
+    finite differences. Just know that if you've got a straight line this
+    method will go a bit haywire.
+
     axis: A vector representing the vertical axis of the coordinate system.
     span: A vector representing the the horiztonal axis of the coordinate system.
 

--- a/polliwog/polyline/inflection_points.py
+++ b/polliwog/polyline/inflection_points.py
@@ -1,4 +1,5 @@
 import numpy as np
+import vg
 
 
 def inflection_points(points, axis, span):
@@ -12,26 +13,25 @@ def inflection_points(points, axis, span):
     returns: a list of points in space corresponding to the vertices that
     immediately preceed inflection points in the curve
     """
+    vg.shape.check(locals(), "points", (-1, 3))
+    vg.shape.check(locals(), "axis", (3,))
+    vg.shape.check(locals(), "span", (3,))
 
     coords_on_span = points.dot(span)
-    dx = np.gradient(coords_on_span)
     coords_on_axis = points.dot(axis)
 
     # Take the second order finite difference of the curve with respect to the
     # defined coordinate system
-    finite_difference_2 = np.gradient(np.gradient(coords_on_axis, dx), dx)
+    finite_difference_2 = np.gradient(
+        np.gradient(coords_on_axis, coords_on_span), coords_on_span
+    )
 
-    # Compare the product of all neighboring pairs of points in the second derivative
-    # If a pair of points has a negative product, then the second derivative changes sign
-    # at one of those points, signalling an inflection point
-    is_inflection_point = [
-        finite_difference_2[i] * finite_difference_2[i + 1] <= 0
-        for i in range(len(finite_difference_2) - 1)
-    ]
+    # Compare the product of all neighboring pairs of points in the second
+    # derivative If a pair of points has a negative product, then the second
+    # derivative changes sign between those points. Those are the inflection
+    # points.
+    is_inflection_point = np.concatenate(
+        [finite_difference_2[:-1] * finite_difference_2[1:] <= 0, [False]]
+    )
 
-    inflection_point_indices = [i for i, b in enumerate(is_inflection_point) if b]
-
-    if len(inflection_point_indices) == 0:  # pylint: disable=len-as-condition
-        return []
-
-    return points[inflection_point_indices]
+    return points[is_inflection_point]

--- a/polliwog/polyline/inflection_points.py
+++ b/polliwog/polyline/inflection_points.py
@@ -30,9 +30,8 @@ def inflection_points(points, axis, span):
 
     # Take the second order finite difference of the curve with respect to the
     # defined coordinate system
-    finite_difference_2 = np.gradient(
-        np.gradient(coords_on_axis, coords_on_span), coords_on_span
-    )
+    finite_difference_1 = np.gradient(coords_on_axis, coords_on_span)
+    finite_difference_2 = np.gradient(finite_difference_1, coords_on_span)
 
     # Compare the product of all neighboring pairs of points in the second
     # derivative. If a pair of points has a negative product, then the second

--- a/polliwog/polyline/inflection_points.py
+++ b/polliwog/polyline/inflection_points.py
@@ -28,7 +28,7 @@ def inflection_points(points, axis, span):
 
     # Compare the product of all neighboring pairs of points in the second
     # derivative. If a pair of points has a negative product, then the second
-    # derivative changes sign between those points. Those are the inflection
+    # derivative changes sign between those points. These are the inflection
     # points.
     is_inflection_point = np.concatenate(
         [finite_difference_2[:-1] * finite_difference_2[1:] <= 0, [False]]

--- a/polliwog/polyline/inflection_points.py
+++ b/polliwog/polyline/inflection_points.py
@@ -27,7 +27,7 @@ def inflection_points(points, axis, span):
     )
 
     # Compare the product of all neighboring pairs of points in the second
-    # derivative If a pair of points has a negative product, then the second
+    # derivative. If a pair of points has a negative product, then the second
     # derivative changes sign between those points. Those are the inflection
     # points.
     is_inflection_point = np.concatenate(

--- a/polliwog/polyline/test_inflection_points.py
+++ b/polliwog/polyline/test_inflection_points.py
@@ -1,0 +1,23 @@
+import numpy as np
+import vg
+from .inflection_points import inflection_points
+
+# Inflection points at x = -3 and x = 4.
+poly_fn = lambda x: (x ** 6) / 30 - (x ** 5) / 20 - (x ** 4) + 3 * x + 20
+
+
+def generate_samples():
+    xs = np.arange(-10, 10, 0.1).reshape(-1, 1)
+    ys = poly_fn(xs)
+    zs = np.zeros_like(xs)
+
+    return np.hstack([xs, ys, zs])
+
+
+def test_inflection_points():
+    samples = generate_samples()
+    result = inflection_points(points=samples, axis=vg.basis.y, span=vg.basis.x)
+    expected_xs = np.array([-3, 4])
+    np.testing.assert_array_almost_equal(result[:, 0], expected_xs, decimal=1)
+    np.testing.assert_array_almost_equal(result[:, 1], poly_fn(result[:, 0]))
+    np.testing.assert_array_almost_equal(result[:, 2], np.zeros_like(expected_xs))

--- a/polliwog/polyline/test_inflection_points.py
+++ b/polliwog/polyline/test_inflection_points.py
@@ -1,23 +1,53 @@
+from collections import namedtuple
 import numpy as np
 import vg
 from .inflection_points import inflection_points
 
-# Inflection points at x = -3 and x = 4.
-poly_fn = lambda x: (x ** 6) / 30 - (x ** 5) / 20 - (x ** 4) + 3 * x + 20
 
-
-def generate_samples():
-    xs = np.arange(-10, 10, 0.1).reshape(-1, 1)
-    ys = poly_fn(xs)
+def generate_samples(fn, domain):
+    xmin, xmax = domain
+    xs = np.arange(xmin, xmax, 0.1).reshape(-1, 1)
+    ys = fn(xs)
     zs = np.zeros_like(xs)
 
     return np.hstack([xs, ys, zs])
 
 
+InflectionPointExample = namedtuple(
+    "InflectionPointExample", ["fn", "domain", "inflection_points"]
+)
+
+
 def test_inflection_points():
-    samples = generate_samples()
-    result = inflection_points(points=samples, axis=vg.basis.y, span=vg.basis.x)
-    expected_xs = np.array([-3, 4])
-    np.testing.assert_array_almost_equal(result[:, 0], expected_xs, decimal=1)
-    np.testing.assert_array_almost_equal(result[:, 1], poly_fn(result[:, 0]))
-    np.testing.assert_array_almost_equal(result[:, 2], np.zeros_like(expected_xs))
+    for example in [
+        InflectionPointExample(
+            fn=lambda x: (x ** 6) / 30 - (x ** 5) / 20 - (x ** 4) + 3 * x + 20,
+            domain=(-10, 10),
+            inflection_points=np.array([-3.0, 4.0]),
+        ),
+        InflectionPointExample(
+            fn=lambda x: x ** 4, domain=(-3, 3), inflection_points=np.array([])
+        ),
+        InflectionPointExample(
+            fn=lambda x: x ** 3, domain=(-3, 3), inflection_points=np.array([0.0])
+        ),
+        InflectionPointExample(
+            fn=lambda x: x ** 3 - 3 * x ** 2 - 144 * x + 432,
+            domain=(-12, 12),
+            inflection_points=np.array([1.0]),
+        ),
+        InflectionPointExample(
+            fn=lambda x: np.sin(2 * x),
+            domain=(0, 2 * np.pi),
+            inflection_points=np.array([1.5, 3.1, 4.7]),
+        ),
+    ]:
+        samples = generate_samples(fn=example.fn, domain=example.domain)
+        result = inflection_points(points=samples, axis=vg.basis.y, span=vg.basis.x)
+        np.testing.assert_array_almost_equal(
+            result[:, 0], example.inflection_points, decimal=1
+        )
+        np.testing.assert_array_almost_equal(result[:, 1], example.fn(result[:, 0]))
+        np.testing.assert_array_almost_equal(
+            result[:, 2], np.zeros_like(example.inflection_points)
+        )


### PR DESCRIPTION
When I run the code that's here with the input I generated, I get a bunch of nan's back, and no inflection points. Looking at [the examples for `np.gradient`](https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.gradient.html), I think the spacing argument is supposed to contain values, not differences between values.

Here's an attempt to fix it.

Though it's possible I've just somehow misunderstood what this is supposed to do!