### PR TITLE
Remove `transform.composite.convert_44_to_33`

### DIFF
--- a/polliwog/transform/composite.py
+++ b/polliwog/transform/composite.py
@@ -21,23 +21,6 @@ def convert_33_to_44(matrix):
     return result
 
 
-def convert_44_to_33(matrix):
-    """
-    Transform from:
-        array([[1., 2., 3., 0.],
-               [2., 3., 4., 0.],
-               [5., 6., 7., 0.],
-               [0., 0., 0., 1.]])
-    to:
-        array([[1., 2., 3.],
-               [2., 3., 4.],
-               [5., 6., 7.]])
-
-    """
-    vg.shape.check(locals(), "matrix", (4, 4))
-    return matrix[:3, :3]
-
-
 class CompositeTransform(object):
     """
     Composite transform using homogeneous coordinates.

--- a/polliwog/transform/test_composite.py
+++ b/polliwog/transform/test_composite.py
@@ -1,7 +1,7 @@
 import numpy as np
 import vg
 import pytest
-from .composite import CompositeTransform, convert_44_to_33
+from .composite import CompositeTransform
 
 
 def create_cube_verts(origin, size):
@@ -231,19 +231,3 @@ def test_forward_reverse_equivalence():
     forward = transform.matrix_for(from_range=(0, 2))
     reverse = transform.matrix_for(from_range=(0, 2), reverse=True)
     np.testing.assert_allclose(reverse, np.linalg.inv(forward))
-
-
-def test_convert_44_to_33():
-    np.testing.assert_array_equal(
-        convert_44_to_33(
-            np.array(
-                [
-                    [1.0, 2.0, 3.0, 0.0],
-                    [2.0, 3.0, 4.0, 0.0],
-                    [5.0, 6.0, 7.0, 0.0],
-                    [0.0, 0.0, 0.0, 1.0],
-                ]
-            )
-        ),
-        np.array([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]),
-    )


### PR DESCRIPTION
If this function is needed, it belongs in `vg.matrix` along with `convert_33_to_44()`. However it seems to be unused.

See https://github.com/lace/vg/pull/90