### PR TITLE
Add `transform.affine_transform()`

### DIFF
--- a/polliwog/transform/affine_transform.py
+++ b/polliwog/transform/affine_transform.py
@@ -1,0 +1,20 @@
+import numpy as np
+import vg
+from .._common.shape import columnize
+
+
+def apply_affine_transform(points, transform_matrix):
+    """
+    Apply the given transformation matrix to the points using homogenous
+    coordinates.
+
+    (This works on any transformation matrix, whether or not it is affine.)
+    """
+    vg.shape.check(locals(), "transform_matrix", (4, 4))
+    points, _, maybe_decolumnize = columnize(points, (-1, 3), name="points")
+
+    padded_points = np.pad(points, ((0, 0), (0, 1)), mode="constant", constant_values=1)
+    transformed_padded_points = np.dot(transform_matrix, padded_points.T).T
+    transformed_points = np.delete(transformed_padded_points, 3, axis=1)
+
+    return maybe_decolumnize(transformed_points)

--- a/polliwog/transform/composite.py
+++ b/polliwog/transform/composite.py
@@ -1,8 +1,9 @@
 import numpy as np
 import vg
+from .affine_transform import apply_affine_transform
 
 
-def convert_33_to_44(matrix):
+def _convert_33_to_44(matrix):
     """
     Transform from:
         array([[1., 2., 3.],
@@ -58,11 +59,12 @@ class CompositeTransform(object):
                 or reverse mode.
 
         """
-        matrix = self.matrix_for(from_range=from_range, reverse=reverse)
+        transform_matrix = self.transform_matrix_for(
+            from_range=from_range, reverse=reverse
+        )
+        return apply_affine_transform(points=points, transform_matrix=transform_matrix)
 
-        return vg.matrix.unpad(np.dot(matrix, vg.matrix.pad_with_ones(points).T).T)
-
-    def matrix_for(self, from_range=None, reverse=False):
+    def transform_matrix_for(self, from_range=None, reverse=False):
         """
         Return a 4x4 transformation matrix representation.
 
@@ -119,12 +121,12 @@ class CompositeTransform(object):
 
         """
         vg.shape.check(locals(), "forward", (3, 3))
-        forward4 = convert_33_to_44(forward)
+        forward4 = _convert_33_to_44(forward)
         if reverse is None:
             reverse4 = None
         else:
             vg.shape.check(locals(), "reverse", (3, 3))
-            reverse4 = convert_33_to_44(reverse)
+            reverse4 = _convert_33_to_44(reverse)
         return self.append_transform4(forward4, reverse4)
 
     def scale(self, factor):

--- a/polliwog/transform/test_affine_transform.py
+++ b/polliwog/transform/test_affine_transform.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from .affine_transform import apply_affine_transform
 
 scale_factor = np.array([3.0, 0.5, 2.0])

--- a/polliwog/transform/test_affine_transform.py
+++ b/polliwog/transform/test_affine_transform.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pytest
+from .affine_transform import apply_affine_transform
+
+scale_factor = np.array([3.0, 0.5, 2.0])
+transform = np.array(
+    [
+        [scale_factor[0], 0, 0, 0],
+        [0, scale_factor[1], 0, 0],
+        [0, 0, scale_factor[2], 0],
+        [0, 0, 0, 1],
+    ]
+)
+
+
+def test_apply_homogeneous():
+    point = np.array([5.0, 0.0, 1.0])
+    expected_point = np.array([15.0, 0.0, 2.0])
+    np.testing.assert_array_equal(
+        apply_affine_transform(point, transform), expected_point
+    )
+
+
+def test_apply_homogeneous_stacked():
+    points = np.array([[1.0, 2.0, 3.0], [5.0, 0.0, 1.0]])
+    expected_points = np.array([[3.0, 1.0, 6.0], [15.0, 0.0, 2.0]])
+    np.testing.assert_array_equal(
+        apply_affine_transform(points, transform), expected_points
+    )

--- a/polliwog/transform/test_composite.py
+++ b/polliwog/transform/test_composite.py
@@ -205,10 +205,10 @@ def test_forward_reverse_equivalence():
     transform.scale(10.0)
     transform.rotate(np.array([7.0, 13.0, 5.0]))
 
-    forward = transform.matrix_for()
-    reverse = transform.matrix_for(reverse=True)
+    forward = transform.transform_matrix_for()
+    reverse = transform.transform_matrix_for(reverse=True)
     np.testing.assert_allclose(reverse, np.linalg.inv(forward))
 
-    forward = transform.matrix_for(from_range=(0, 2))
-    reverse = transform.matrix_for(from_range=(0, 2), reverse=True)
+    forward = transform.transform_matrix_for(from_range=(0, 2))
+    reverse = transform.transform_matrix_for(from_range=(0, 2), reverse=True)
     np.testing.assert_allclose(reverse, np.linalg.inv(forward))


### PR DESCRIPTION
- Stop using `vg.matrix`
- Inline `pad` and `unpad` which aren’t really useful outside this context
- Make `convert_33_to_44()` private for the moment

Ref #107