### PR TITLE
Restore `find_rigid_rotation()`

### DIFF
--- a/polliwog/transform/__init__.py
+++ b/polliwog/transform/__init__.py
@@ -1,5 +1,4 @@
 from .composite import CompositeTransform  # noqa: F401
 from .coordinate_manager import CoordinateManager  # noqa: F401
 from .rigid_transform import find_rigid_rotation, find_rigid_transform  # noqa: F401
-from .rigid_transform import find_rigid_transform  # noqa: F401
 from .rotation import rotation_from_up_and_look  # noqa: F401

--- a/polliwog/transform/__init__.py
+++ b/polliwog/transform/__init__.py
@@ -1,4 +1,5 @@
 from .composite import CompositeTransform  # noqa: F401
 from .coordinate_manager import CoordinateManager  # noqa: F401
+from .rigid_transform import find_rigid_rotation, find_rigid_transform  # noqa: F401
 from .rigid_transform import find_rigid_transform  # noqa: F401
 from .rotation import rotation_from_up_and_look  # noqa: F401


### PR DESCRIPTION
This reverts commit 06950e412adef614913d8e42d908f5a2d2f6faf8.

# Conflicts:
#	polliwog/transform/__init__.py

Ref #91 #95