### PR TITLE
Fix contains_coplanar_point (with test)

### DIFF
--- a/polliwog/tri/functions.py
+++ b/polliwog/tri/functions.py
@@ -46,7 +46,6 @@ def contains_coplanar_point(a, b, c, point):
     vg.shape.check(locals(), "b", (3,))
     vg.shape.check(locals(), "c", (3,))
     vg.shape.check(locals(), "point", (3,))
-    import pdb; pdb.set_trace()
 
     # Uses "same-side technique" from http://blackpawn.com/texts/pointinpoly/default.html
     return (

--- a/polliwog/tri/functions.py
+++ b/polliwog/tri/functions.py
@@ -26,7 +26,7 @@ def surface_normals(points, normalize=True):
     return transform_result(normals)
 
 
-def coplanar_points_are_on_same_side_of_line(a, b, p1, p2, atol=1e-8):
+def coplanar_points_are_on_same_side_of_line(a, b, p1, p2):
     vg.shape.check(locals(), "a", (3,))
     vg.shape.check(locals(), "b", (3,))
     vg.shape.check(locals(), "p1", (3,))
@@ -34,10 +34,10 @@ def coplanar_points_are_on_same_side_of_line(a, b, p1, p2, atol=1e-8):
 
     # Uses "same-side technique" from http://blackpawn.com/texts/pointinpoly/default.html
     along_line = b - a
-    return vg.dot(vg.cross(along_line, p1 - a), vg.cross(along_line, p2 - a)) >= -atol
+    return vg.dot(vg.cross(along_line, p1 - a), vg.cross(along_line, p2 - a)) >= 0
 
 
-def contains_coplanar_point(a, b, c, point, atol=1e-8):
+def contains_coplanar_point(a, b, c, point):
     """
     Assuming `point` is coplanar with the triangle `ABC`, check if it lies
     inside it.
@@ -46,12 +46,13 @@ def contains_coplanar_point(a, b, c, point, atol=1e-8):
     vg.shape.check(locals(), "b", (3,))
     vg.shape.check(locals(), "c", (3,))
     vg.shape.check(locals(), "point", (3,))
+    import pdb; pdb.set_trace()
 
     # Uses "same-side technique" from http://blackpawn.com/texts/pointinpoly/default.html
     return (
-        coplanar_points_are_on_same_side_of_line(b, c, point, a, atol=atol)
-        and coplanar_points_are_on_same_side_of_line(a, c, point, b, atol=atol)
-        and coplanar_points_are_on_same_side_of_line(a, b, point, c, atol=atol)
+        coplanar_points_are_on_same_side_of_line(b, c, point, a)
+        and coplanar_points_are_on_same_side_of_line(a, c, point, b)
+        and coplanar_points_are_on_same_side_of_line(a, b, point, c)
     )
 
 

--- a/polliwog/tri/test_functions.py
+++ b/polliwog/tri/test_functions.py
@@ -51,26 +51,36 @@ def test_contains_coplanar_point():
     b = np.array([4.0, 0.1, 0.0])
     c = np.array([3.0, 3.1, 0.0])
 
-    # Not sure why, but `is True` does not work.
-    assert contains_coplanar_point(a, b, c, a) == True  # noqa: E712
-    assert contains_coplanar_point(a, b, c, b) == True  # noqa: E712
-    assert contains_coplanar_point(a, b, c, c) == True  # noqa: E712
-    assert (
-        contains_coplanar_point(a, b, c, np.array([2.0, 1.0, 0.0])) == True
-    )  # noqa: E712
+    # # Not sure why, but `is True` does not work.
+    # assert contains_coplanar_point(a, b, c, a) == True  # noqa: E712
+    # assert contains_coplanar_point(a, b, c, b) == True  # noqa: E712
+    # assert contains_coplanar_point(a, b, c, c) == True  # noqa: E712
+    # assert (
+    #     contains_coplanar_point(a, b, c, np.array([2.0, 1.0, 0.0])) == True
+    # )  # noqa: E712
 
-    # Unexpected, as it's not in the plane, though if projected to the plane,
-    # it is in the triangle.
-    assert (
-        contains_coplanar_point(a, b, c, np.array([0.0, 0.0, 1.0])) == True
-    )  # noqa: E712
+    # # Unexpected, as it's not in the plane, though if projected to the plane,
+    # # it is in the triangle.
+    # assert (
+    #     contains_coplanar_point(a, b, c, np.array([0.0, 0.0, 1.0])) == True
+    # )  # noqa: E712
+
+    # assert (
+    #     contains_coplanar_point(a, b, c, np.array([2.0, 0.0, 0.0])) == False
+    # )  # noqa: E712
+    # assert (
+    #     contains_coplanar_point(a, b, c, np.array([2.0, 5.0, 0.0])) == False
+    # )  # noqa: E712
 
     assert (
-        contains_coplanar_point(a, b, c, np.array([2.0, 0.0, 0.0])) == False
-    )  # noqa: E712
-    assert (
-        contains_coplanar_point(a, b, c, np.array([2.0, 5.0, 0.0])) == False
-    )  # noqa: E712
+        contains_coplanar_point(
+            np.array([0.06710189, 1.69908346, 0.06590126]),
+            np.array([0.05648619, 1.70207, 0.07402092]),
+            np.array([0.05969098, 1.69641423, 0.07268801]),
+            np.array([0.07534771, 1.6869296, 0.06190757]),
+        )
+        == False
+    )
 
 
 def test_barycentric():

--- a/polliwog/tri/test_functions.py
+++ b/polliwog/tri/test_functions.py
@@ -51,26 +51,26 @@ def test_contains_coplanar_point():
     b = np.array([4.0, 0.1, 0.0])
     c = np.array([3.0, 3.1, 0.0])
 
-    # # Not sure why, but `is True` does not work.
-    # assert contains_coplanar_point(a, b, c, a) == True  # noqa: E712
-    # assert contains_coplanar_point(a, b, c, b) == True  # noqa: E712
-    # assert contains_coplanar_point(a, b, c, c) == True  # noqa: E712
-    # assert (
-    #     contains_coplanar_point(a, b, c, np.array([2.0, 1.0, 0.0])) == True
-    # )  # noqa: E712
+    # Not sure why, but `is True` does not work.
+    assert contains_coplanar_point(a, b, c, a) == True  # noqa: E712
+    assert contains_coplanar_point(a, b, c, b) == True  # noqa: E712
+    assert contains_coplanar_point(a, b, c, c) == True  # noqa: E712
+    assert (
+        contains_coplanar_point(a, b, c, np.array([2.0, 1.0, 0.0])) == True
+    )  # noqa: E712
 
-    # # Unexpected, as it's not in the plane, though if projected to the plane,
-    # # it is in the triangle.
-    # assert (
-    #     contains_coplanar_point(a, b, c, np.array([0.0, 0.0, 1.0])) == True
-    # )  # noqa: E712
+    # Unexpected, as it's not in the plane, though if projected to the plane,
+    # it is in the triangle.
+    assert (
+        contains_coplanar_point(a, b, c, np.array([0.0, 0.0, 1.0])) == True
+    )  # noqa: E712
 
-    # assert (
-    #     contains_coplanar_point(a, b, c, np.array([2.0, 0.0, 0.0])) == False
-    # )  # noqa: E712
-    # assert (
-    #     contains_coplanar_point(a, b, c, np.array([2.0, 5.0, 0.0])) == False
-    # )  # noqa: E712
+    assert (
+        contains_coplanar_point(a, b, c, np.array([2.0, 0.0, 0.0])) == False
+    )  # noqa: E712
+    assert (
+        contains_coplanar_point(a, b, c, np.array([2.0, 5.0, 0.0])) == False
+    )  # noqa: E712
 
     assert (
         contains_coplanar_point(


### PR DESCRIPTION
Remove possibly ill-advised `atol` parameter from these, at least until someone asks and provides a test case that demonstrates its usefulness.