### PR TITLE
Transforms: Add flipping and non-uniform scale

### DIFF
--- a/polliwog/transform/_composite_transform.py
+++ b/polliwog/transform/_composite_transform.py
@@ -109,6 +109,9 @@ class CompositeTransform(object):
 
         Args:
             factor (float): The scale factor.
+
+        See also:
+            `non_uniform_scale()`
         """
         forward, inverse = transform_matrix_for_uniform_scale(
             factor, allow_flipping=allow_flipping, ret_inverse_matrix=True
@@ -117,12 +120,15 @@ class CompositeTransform(object):
 
     def non_uniform_scale(self, x_factor, y_factor, z_factor, allow_flipping=False):
         """
-        Scale by the given factors along `x`, `y`, and `z`
+        Scale by the given factors along `x`, `y`, and `z`.
 
         Args:
             x_factor (float): The scale factor to be applied along the `x` axis.
             y_factor (float): The scale factor to be applied along the `y` axis.
             z_factor (float): The scale factor to be applied along the `z` axis.
+
+        See also:
+            `uniform_scale()`
         """
         forward, inverse = transform_matrix_for_non_uniform_scale(
             x_factor,

--- a/polliwog/transform/_composite_transform.py
+++ b/polliwog/transform/_composite_transform.py
@@ -4,8 +4,8 @@ from ._affine_transform import (
     apply_affine_transform,
     transform_matrix_for_non_uniform_scale,
     transform_matrix_for_rotation,
-    transform_matrix_for_uniform_scale,
     transform_matrix_for_translation,
+    transform_matrix_for_uniform_scale,
 )
 from ._rotation import rotation_from_up_and_look
 

--- a/polliwog/transform/_composite_transform.py
+++ b/polliwog/transform/_composite_transform.py
@@ -2,8 +2,9 @@ import numpy as np
 import vg
 from ._affine_transform import (
     apply_affine_transform,
+    transform_matrix_for_non_uniform_scale,
     transform_matrix_for_rotation,
-    transform_matrix_for_scale,
+    transform_matrix_for_uniform_scale,
     transform_matrix_for_translation,
 )
 from ._rotation import rotation_from_up_and_look
@@ -15,7 +16,7 @@ class CompositeTransform(object):
 
     Example:
         >>> transform = CompositeTransform()
-        >>> transform.scale(10)
+        >>> transform.uniform_scale(10)
         >>> transform.reorient(up=[0, 1, 0], look=[-1, 0, 0])
         >>> transform.translate([0, -2.5, 0])
         >>> transformed_scan = transform(scan_v)
@@ -102,14 +103,34 @@ class CompositeTransform(object):
         self.transforms.append((forward, reverse))
         return new_index
 
-    def scale(self, factor):
+    def uniform_scale(self, factor, allow_flipping=False):
         """
         Scale by the given factor.
 
         Args:
             factor (float): The scale factor.
         """
-        forward, inverse = transform_matrix_for_scale(factor, ret_inverse_matrix=True)
+        forward, inverse = transform_matrix_for_uniform_scale(
+            factor, allow_flipping=allow_flipping, ret_inverse_matrix=True
+        )
+        return self.append_transform(forward, inverse)
+
+    def non_uniform_scale(self, x_factor, y_factor, z_factor, allow_flipping=False):
+        """
+        Scale by the given factors along `x`, `y`, and `z`
+
+        Args:
+            x_factor (float): The scale factor to be applied along the `x` axis.
+            y_factor (float): The scale factor to be applied along the `y` axis.
+            z_factor (float): The scale factor to be applied along the `z` axis.
+        """
+        forward, inverse = transform_matrix_for_non_uniform_scale(
+            x_factor,
+            y_factor,
+            z_factor,
+            allow_flipping=allow_flipping,
+            ret_inverse_matrix=True,
+        )
         return self.append_transform(forward, inverse)
 
     def convert_units(self, from_units, to_units):
@@ -119,7 +140,7 @@ class CompositeTransform(object):
         These calls are equivalent:
 
         >>> composite.convert_units(from_units='cm', to_units='m')
-        >>> composite.scale(.01)
+        >>> composite.uniform_scale(.01)
 
         Supports the length units from Ounce:
         https://github.com/lace/ounce/blob/master/ounce/core.py#L26
@@ -127,7 +148,21 @@ class CompositeTransform(object):
         import ounce
 
         factor = ounce.factor(from_units, to_units)
-        return self.scale(factor)
+        return self.uniform_scale(factor)
+
+    def flip(self, dim):
+        """
+        Flip about one of the axes.
+
+        Args:
+            dim (int): The axis to flip about: 0 for `x`, 1 for `y`, 2 for `z`.
+        """
+        if dim not in (0, 1, 2):
+            raise ValueError("Expected dim to be 0, 1, or 2")
+
+        scale_factors = np.ones(3)
+        scale_factors[dim] = -1.0
+        return self.non_uniform_scale(*scale_factors, allow_flipping=True)
 
     def translate(self, translation):
         """

--- a/polliwog/transform/_coordinate_manager.py
+++ b/polliwog/transform/_coordinate_manager.py
@@ -8,7 +8,7 @@ class CoordinateManager(object):
         >>> coordinate_manager = CoordinateManager()
         >>> coordinate_manager.tag_as('source')
         >>> coordinate_manager.translate(-cube.floor_point)
-        >>> coordinate_manager.scale(2)
+        >>> coordinate_manager.uniform_scale(2)
         >>> coordinate_manager.tag_as('floored_and_scaled')
         >>> coordinate_manager.translate(np.array([0., -4., 0.]))
         >>> coordinate_manager.tag_as('centered_at_origin')
@@ -33,11 +33,17 @@ class CoordinateManager(object):
     def append_transform(self, *args, **kwargs):
         self._transform.append_transform(*args, **kwargs)
 
-    def scale(self, *args, **kwargs):
-        self._transform.scale(*args, **kwargs)
+    def uniform_scale(self, *args, **kwargs):
+        self._transform.uniform_scale(*args, **kwargs)
+
+    def non_uniform_scale(self, *args, **kwargs):
+        self._transform.non_uniform_scale(*args, **kwargs)
 
     def convert_units(self, *args, **kwargs):
         self._transform.convert_units(*args, **kwargs)
+
+    def flip(self, *args, **kwargs):
+        self._transform.flip(*args, **kwargs)
 
     def translate(self, *args, **kwargs):
         self._transform.translate(*args, **kwargs)

--- a/polliwog/transform/test_composite_transform.py
+++ b/polliwog/transform/test_composite_transform.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import vg
 from ._composite_transform import CompositeTransform
 from .test_affine_transform import create_default_cube_verts
@@ -23,7 +24,7 @@ def test_convert_units():
 def test_translate_then_scale():
     transform = CompositeTransform()
     transform.translate(np.array([8.0, 6.0, 7.0]))
-    transform.scale(10.0)
+    transform.uniform_scale(10.0)
 
     cube_v = create_default_cube_verts()
 
@@ -39,7 +40,7 @@ def test_translate_then_scale():
 
 def test_scale_then_translate():
     transform = CompositeTransform()
-    transform.scale(10.0)
+    transform.uniform_scale(10.0)
     transform.translate(np.array([8.0, 6.0, 7.0]))
 
     cube_v = create_default_cube_verts()
@@ -95,12 +96,12 @@ def test_reverse_transforms():
 
     transforms[1].translate(np.array([8.0, 6.0, 7.0]))
 
-    transforms[2].scale(10.0)
+    transforms[2].uniform_scale(10.0)
 
     transforms[3].translate(np.array([8.0, 6.0, 7.0]))
-    transforms[3].scale(10.0)
+    transforms[3].uniform_scale(10.0)
 
-    transforms[4].scale(10.0)
+    transforms[4].uniform_scale(10.0)
     transforms[4].translate(np.array([8.0, 6.0, 7.0]))
 
     for transform in transforms:
@@ -122,7 +123,7 @@ def test_forward_reverse_equivalence():
     transform = CompositeTransform()
     transform.rotate(np.array([1.0, 2.0, 3.0]))
     transform.translate(np.array([3.0, 2.0, 1.0]))
-    transform.scale(10.0)
+    transform.uniform_scale(10.0)
     transform.rotate(np.array([7.0, 13.0, 5.0]))
 
     forward = transform.transform_matrix_for()
@@ -132,3 +133,8 @@ def test_forward_reverse_equivalence():
     forward = transform.transform_matrix_for(from_range=(0, 2))
     reverse = transform.transform_matrix_for(from_range=(0, 2), reverse=True)
     np.testing.assert_allclose(reverse, np.linalg.inv(forward))
+
+def test_flip_error():
+    transform = CompositeTransform()
+    with pytest.raises(ValueError, match=r"Expected dim to be 0, 1, or 2"):
+        transform.flip(-1)

--- a/polliwog/transform/test_composite_transform.py
+++ b/polliwog/transform/test_composite_transform.py
@@ -134,6 +134,7 @@ def test_forward_reverse_equivalence():
     reverse = transform.transform_matrix_for(from_range=(0, 2), reverse=True)
     np.testing.assert_allclose(reverse, np.linalg.inv(forward))
 
+
 def test_flip_error():
     transform = CompositeTransform()
     with pytest.raises(ValueError, match=r"Expected dim to be 0, 1, or 2"):

--- a/polliwog/transform/test_coordinate_manager.py
+++ b/polliwog/transform/test_coordinate_manager.py
@@ -6,6 +6,10 @@ from .test_affine_transform import create_cube_verts
 
 
 def perform_transform_test(apply_transform_fn, expected_v0, expected_v6):
+    """
+    Untransformed v0: [1.0, 0.0, 0.0]
+    Untransformed v6: [5.0, 4.0, 4.0]
+    """
     cube_v = create_cube_verts([1.0, 0.0, 0.0], 4.0)
 
     coordinate_manager = CoordinateManager()
@@ -33,7 +37,7 @@ def test_coordinate_manager_forward():
     coordinate_manager = CoordinateManager()
     coordinate_manager.tag_as("source")
     coordinate_manager.translate(-cube_floor_point)
-    coordinate_manager.scale(2)
+    coordinate_manager.uniform_scale(2)
     coordinate_manager.tag_as("floored_and_scaled")
     coordinate_manager.translate(np.array([0.0, -4.0, 0.0]))
     coordinate_manager.tag_as("centered_at_origin")
@@ -81,7 +85,7 @@ def test_coordinate_manager_forward_with_attrs():
     coordinate_manager = CoordinateManager()
     coordinate_manager.tag_as("source")
     coordinate_manager.translate(-cube_floor_point)
-    coordinate_manager.scale(2)
+    coordinate_manager.uniform_scale(2)
     coordinate_manager.tag_as("floored_and_scaled")
     coordinate_manager.translate(np.array([0.0, -4.0, 0.0]))
     coordinate_manager.tag_as("centered_at_origin")
@@ -107,7 +111,7 @@ def test_coordinate_manager_forward_with_attrs():
 def test_coordinate_manager_out_of_order():
     coordinate_manager = CoordinateManager()
     coordinate_manager.tag_as("before")
-    coordinate_manager.scale(2)
+    coordinate_manager.uniform_scale(2)
     coordinate_manager.tag_as("after")
 
     with pytest.raises(ValueError):
@@ -119,7 +123,7 @@ def test_coordinate_manager_invalid_tag():
 
     coordinate_manager = CoordinateManager()
     coordinate_manager.tag_as("before")
-    coordinate_manager.scale(2)
+    coordinate_manager.uniform_scale(2)
     coordinate_manager.tag_as("after")
 
     with pytest.raises(AttributeError):
@@ -169,4 +173,22 @@ def test_coordinate_manager_rotate():
         ),
         expected_v0=np.array([0.0, 0.0, -1.0]),
         expected_v6=np.array([4, 4.0, -5.0]),
+    )
+
+
+def test_coordinate_manager_non_uniform_scale():
+    perform_transform_test(
+        apply_transform_fn=lambda coordinate_manager: coordinate_manager.non_uniform_scale(
+            1.0, 2.0, 3.0
+        ),
+        expected_v0=np.array([1.0, 0.0, 0.0]),
+        expected_v6=np.array([5, 8.0, 12.0]),
+    )
+
+
+def test_coordinate_manager_flip():
+    perform_transform_test(
+        apply_transform_fn=lambda coordinate_manager: coordinate_manager.flip(1),
+        expected_v0=np.array([1.0, 0.0, 0.0]),
+        expected_v6=np.array([5.0, -4.0, 4.0]),
     )


### PR DESCRIPTION
BREAKING CHANGE

- CompositeTransform, CoordinateManager: `scale()` is renamed to `uniform_scale()`
- `polliwog.transform.transform_matrix_for_scale` is renamed to `polliwog.transform.transform_matrix_for_uniform_scale`

New features

- CompositeTransform, CoordinateManager: Add `non_uniform_scale()`
- CompositeTransform, CoordinateManager: Add `flip()`
- `polliwog.transform.transform_matrix_for_scale`: Add `allow_flipping` parameter.
- Add `polliwog.transform.transform_matrix_for_non_uniform_scale`