### PR TITLE
Box: Add bounding planes

### DIFF
--- a/polliwog/box/_box_object.py
+++ b/polliwog/box/_box_object.py
@@ -1,5 +1,6 @@
 import numpy as np
 import vg
+from ..plane._plane_object import Plane
 
 
 class Box(object):
@@ -112,6 +113,66 @@ class Box(object):
         The `z` coordinate of the box's center.
         """
         return self.origin[2] + self.size[2] / 2
+
+    @property
+    def min_x_plane(self):
+        """
+        The plane facing the inside of the box, aligned with its minimum
+        `x` coordinate.
+        """
+        center_of_side = self.center_point
+        center_of_side[0] = self.min_x
+        return Plane(center_of_side, vg.basis.x)
+
+    @property
+    def min_y_plane(self):
+        """
+        The plane facing the inside of the box, aligned with its minimum
+        `y` coordinate.
+        """
+        center_of_side = self.center_point
+        center_of_side[1] = self.min_y
+        return Plane(center_of_side, vg.basis.y)
+
+    @property
+    def min_z_plane(self):
+        """
+        The plane facing the inside of the box, aligned with its minimum
+        `z` coordinate.
+        """
+        center_of_side = self.center_point
+        center_of_side[2] = self.min_z
+        return Plane(center_of_side, vg.basis.z)
+
+    @property
+    def max_x_plane(self):
+        """
+        The plane facing the inside of the box, aligned with its maximum
+        `x` coordinate.
+        """
+        center_of_side = self.center_point
+        center_of_side[0] = self.max_x
+        return Plane(center_of_side, vg.basis.neg_x)
+
+    @property
+    def max_y_plane(self):
+        """
+        The plane facing the inside of the box, aligned with its maximum
+        `y` coordinate.
+        """
+        center_of_side = self.center_point
+        center_of_side[1] = self.max_y
+        return Plane(center_of_side, vg.basis.neg_y)
+
+    @property
+    def max_z_plane(self):
+        """
+        The plane facing the inside of the box, aligned with its maximum
+        `z` coordinate.
+        """
+        center_of_side = self.center_point
+        center_of_side[2] = self.max_z
+        return Plane(center_of_side, vg.basis.neg_z)
 
     @property
     def width(self):

--- a/polliwog/box/test_box_object.py
+++ b/polliwog/box/test_box_object.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import vg
 from ._box_object import Box
 
 
@@ -24,6 +25,23 @@ def test_mins_mids_maxes():
     assert box.max_x == 4.0
     assert box.max_y == 3.0
     assert box.max_z == 8.0
+
+
+def test_min_max_planes():
+    box = create_box()
+    assert box.min_x_plane.reference_point[0] == 1.0
+    assert box.min_y_plane.reference_point[1] == 2.0
+    assert box.min_z_plane.reference_point[2] == 3.0
+    assert box.max_x_plane.reference_point[0] == 4.0
+    assert box.max_y_plane.reference_point[1] == 3.0
+    assert box.max_z_plane.reference_point[2] == 8.0
+
+    np.testing.assert_array_equal(box.min_x_plane.normal, vg.basis.x)
+    np.testing.assert_array_equal(box.min_y_plane.normal, vg.basis.y)
+    np.testing.assert_array_equal(box.min_z_plane.normal, vg.basis.z)
+    np.testing.assert_array_equal(box.max_x_plane.normal, vg.basis.neg_x)
+    np.testing.assert_array_equal(box.max_y_plane.normal, vg.basis.neg_y)
+    np.testing.assert_array_equal(box.max_z_plane.normal, vg.basis.neg_z)
 
 
 def test_dims():


### PR DESCRIPTION
These will be used in place of a `floor_point` in lacecore. The name `floor_point` makes an assumption about being in a y-up coordinate system, so it's better to let the caller use `mesh.bounding_box.min_y_plane`, or `mesh.bounding_box.min_z_plane` for a z-up coordinate system.