### PR TITLE
Fix issue where `flipped()` creates non-contiguous arrays

### DIFF
--- a/polliwog/polyline/_polyline_object.py
+++ b/polliwog/polyline/_polyline_object.py
@@ -252,7 +252,9 @@ class Polyline(object):
         """
         Flip the polyline from end to end. Return a new polyline.
         """
-        return Polyline(v=np.flipud(self.v), is_closed=self.is_closed)
+        return Polyline(
+            v=np.ascontiguousarray(np.flipud(self.v)), is_closed=self.is_closed
+        )
 
     def aligned_with(self, vector):
         """

--- a/polliwog/polyline/test_polyline_object.py
+++ b/polliwog/polyline/test_polyline_object.py
@@ -601,6 +601,24 @@ def test_flipped():
     np.testing.assert_array_almost_equal(flipped.v, expected_v)
 
 
+def test_flipped_preserves_flags():
+    original = Polyline(
+        np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+                [1.0, 7.0, 0.0],
+                [1.0, 8.0, 0.0],
+                [0.0, 8.0, 0.0],
+            ]
+        ),
+        is_closed=True,
+    )
+    assert original.v.flags['C_CONTIGUOUS'] is True
+    assert original.flipped().v.flags['C_CONTIGUOUS'] is True
+
+
 def test_aligned_with():
     original = Polyline(
         np.array(

--- a/polliwog/polyline/test_polyline_object.py
+++ b/polliwog/polyline/test_polyline_object.py
@@ -615,8 +615,8 @@ def test_flipped_preserves_flags():
         ),
         is_closed=True,
     )
-    assert original.v.flags['C_CONTIGUOUS'] is True
-    assert original.flipped().v.flags['C_CONTIGUOUS'] is True
+    assert original.v.flags["C_CONTIGUOUS"] is True
+    assert original.flipped().v.flags["C_CONTIGUOUS"] is True
 
 
 def test_aligned_with():


### PR DESCRIPTION
Non-contiguous arrays do not work with PyCollada.