### PR TITLE
Revert "Fix issue where `flipped()` creates non-contiguous arrays (#272)"

### DIFF
--- a/polliwog/polyline/_polyline_object.py
+++ b/polliwog/polyline/_polyline_object.py
@@ -252,9 +252,7 @@ class Polyline(object):
         """
         Flip the polyline from end to end. Return a new polyline.
         """
-        return Polyline(
-            v=np.ascontiguousarray(np.flipud(self.v)), is_closed=self.is_closed
-        )
+        return Polyline(v=np.flipud(self.v), is_closed=self.is_closed)
 
     def aligned_with(self, vector):
         """

--- a/polliwog/polyline/test_polyline_object.py
+++ b/polliwog/polyline/test_polyline_object.py
@@ -601,24 +601,6 @@ def test_flipped():
     np.testing.assert_array_almost_equal(flipped.v, expected_v)
 
 
-def test_flipped_preserves_flags():
-    original = Polyline(
-        np.array(
-            [
-                [0.0, 0.0, 0.0],
-                [1.0, 0.0, 0.0],
-                [1.0, 1.0, 0.0],
-                [1.0, 7.0, 0.0],
-                [1.0, 8.0, 0.0],
-                [0.0, 8.0, 0.0],
-            ]
-        ),
-        is_closed=True,
-    )
-    assert original.v.flags["C_CONTIGUOUS"] is True
-    assert original.flipped().v.flags["C_CONTIGUOUS"] is True
-
-
 def test_aligned_with():
     original = Polyline(
         np.array(


### PR DESCRIPTION
This reverts commit b02f36d5ce6868cc1f15a3752fafd28756f329f8.

Increasingly I don't think this makes sense. Non-contiguous arrays are common enough in NumPy that I don't think it's a bug for Polliwog to return a non-contiguous array.

The thing which can't handle non-contiguous arrays is PyCollada, which I've patched around with this alternative fix: lace/tri-again#54