### PR TITLE
BREAKING CHANGE: Change Plane constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## 3.0.0-alpha.1 (Apr. 13, 2022)
-
 ## 3.0.0-alpha.0 (Apr. 8, 2022)
 
 - Rework serialization and deserialization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 3.0.0-alpha.1 (Apr. 13, 2022)
+
 ## 3.0.0-alpha.0 (Apr. 8, 2022)
 
 - Rework serialization and deserialization

--- a/polliwog/plane/_plane_object.py
+++ b/polliwog/plane/_plane_object.py
@@ -50,7 +50,7 @@ class Plane:
         return "<Plane of {} through {}>".format(self.normal, self.reference_point)
 
     @classmethod
-    def from_point_and_normal(cls, reference_point, normal):
+    def from_point_and_normal(cls, reference_point, normal, direction_decimals=None):
         """
         Create a plane using the given reference point and normal vector, which
         will be normalized for you.
@@ -60,11 +60,18 @@ class Plane:
                 NumPy array with three coordinates.
             normal (np.ndarray): The plane normal vector, with unit length, as a
                 NumPy array with three coordinates.
+            direction_decimals (int): The desired number of decimal places for
+                validating that `normal` has unit length. The default is
+                `DEFAULT_DIRECTION_DECIMALS`.
 
         Returns:
             Plane: The requested plane.
         """
-        return cls(reference_point=reference_point, normal=vg.normalize(normal))
+        return cls(
+            reference_point=reference_point,
+            normal=vg.normalize(normal),
+            direction_decimals=direction_decimals,
+        )
 
     @classmethod
     def from_points(cls, p1, p2, p3):
@@ -80,7 +87,7 @@ class Plane:
         return cls(reference_point=p1, normal=plane_normal_from_points(points))
 
     @classmethod
-    def from_points_and_vector(cls, p1, p2, vector):
+    def from_points_and_vector(cls, p1, p2, vector, direction_decimals=None):
         """
         Compute a plane which contains two given points and the given
         vector. Its reference point will be p1.
@@ -94,13 +101,20 @@ class Plane:
         your result plane should be perpendicular, and specify vector
         as its normal vector.
 
+        Args:
+            direction_decimals (int): The desired number of decimal places for
+                validating that `normal` has unit length. The default is
+                `DEFAULT_DIRECTION_DECIMALS`.
+
         """
         vg.shape.check(locals(), "p1", (3,))
         vg.shape.check(locals(), "p2", (3,))
         vg.shape.check(locals(), "vector", (3,))
 
         return cls.from_point_and_normal(
-            reference_point=p1, normal=np.cross(p2 - p1, vector)
+            reference_point=p1,
+            normal=np.cross(p2 - p1, vector),
+            direction_decimals=direction_decimals,
         )
 
     @classmethod

--- a/polliwog/plane/_plane_object.py
+++ b/polliwog/plane/_plane_object.py
@@ -17,6 +17,9 @@ class Plane:
             NumPy array with three coordinates.
         normal (np.ndarray): The plane normal vector, with unit length, as a
             NumPy array with three coordinates.
+        direction_decimals (int): The desired number of decimal places for
+            validating that `normal` has unit length. The default is
+            `DEFAULT_DIRECTION_DECIMALS`.
 
     Note:
         To construct a plane from a non-unit length normal, use
@@ -27,13 +30,14 @@ class Plane:
     DEFAULT_POSITION_DECIMALS = 6
     DEFAULT_DIRECTION_DECIMALS = 6
 
-    def __init__(self, reference_point, normal):
+    def __init__(self, reference_point, normal, direction_decimals=None):
+        if direction_decimals is None:
+            direction_decimals = self.DEFAULT_DIRECTION_DECIMALS
+
         vg.shape.check(locals(), "reference_point", (3,))
         vg.shape.check(locals(), "normal", (3,))
 
-        if not vg.almost_unit_length(
-            normal, atol=0.1**self.DEFAULT_DIRECTION_DECIMALS
-        ):
+        if not vg.almost_unit_length(normal, atol=0.1**direction_decimals):
             raise ValueError("normal should have unit length")
 
         self.reference_point = np.copy(reference_point)

--- a/polliwog/plane/_plane_object.py
+++ b/polliwog/plane/_plane_object.py
@@ -10,33 +10,57 @@ from ._plane_functions import (
 
 class Plane(object):
     """
-    A 2-D plane in 3-space (not a hyperplane).
+    An immutable 2D plane (not a hyperplane) in 3D space.
 
     Args:
-        point_on_plane (np.arraylike): A reference point on the plane, as a
+        reference_point (np.ndarray): A reference point on the plane, as a
             NumPy array with three coordinates.
-        unit_normal (np.arraylike): The plane normal vector, as a NumPy
-            array with three coordinates.
+        normal (np.ndarray): The plane normal vector, with unit length, as a
+            NumPy array with three coordinates.
+
+    Note:
+        To construct a plane from a non-unit length normal, use
+        `Plane.from_point_and_normal()`.
     """
 
     POSITION_DTYPE = np.float64
     DEFAULT_POSITION_DECIMALS = 6
     DEFAULT_DIRECTION_DECIMALS = 6
 
-    def __init__(self, point_on_plane, unit_normal):
-        vg.shape.check(locals(), "point_on_plane", (3,))
-        vg.shape.check(locals(), "unit_normal", (3,))
+    def __init__(self, reference_point, normal):
+        vg.shape.check(locals(), "reference_point", (3,))
+        vg.shape.check(locals(), "normal", (3,))
 
-        if vg.almost_zero(unit_normal):
-            raise ValueError("unit_normal should not be the zero vector")
+        if not vg.almost_unit_length(
+            normal, atol=0.1**self.DEFAULT_DIRECTION_DECIMALS
+        ):
+            raise ValueError("normal should have unit length")
 
-        unit_normal = vg.normalize(unit_normal)
+        self.reference_point = np.copy(reference_point)
+        self.reference_point.setflags(write=False)
 
-        self._r0 = np.asarray(point_on_plane)
-        self._n = np.asarray(unit_normal)
+        self.normal = np.copy(normal)
+        self.normal.setflags(write=False)
 
     def __repr__(self):
         return "<Plane of {} through {}>".format(self.normal, self.reference_point)
+
+    @classmethod
+    def from_point_and_normal(cls, reference_point, normal):
+        """
+        Create a plane using the given reference point and normal vector, which
+        will be normalized for you.
+
+        Args:
+            reference_point (np.ndarray): A reference point on the plane, as a
+                NumPy array with three coordinates.
+            normal (np.ndarray): The plane normal vector, with unit length, as a
+                NumPy array with three coordinates.
+
+        Returns:
+            Plane: The requested plane.
+        """
+        return cls(reference_point=reference_point, normal=vg.normalize(normal))
 
     @classmethod
     def from_points(cls, p1, p2, p3):
@@ -49,7 +73,7 @@ class Plane(object):
         vg.shape.check(locals(), "p2", (3,))
         vg.shape.check(locals(), "p3", (3,))
         points = np.array([p1, p2, p3])
-        return cls(point_on_plane=p1, unit_normal=plane_normal_from_points(points))
+        return cls(reference_point=p1, normal=plane_normal_from_points(points))
 
     @classmethod
     def from_points_and_vector(cls, p1, p2, vector):
@@ -71,9 +95,9 @@ class Plane(object):
         vg.shape.check(locals(), "p2", (3,))
         vg.shape.check(locals(), "vector", (3,))
 
-        normal = np.cross(p2 - p1, vector)
-
-        return cls(point_on_plane=p1, unit_normal=normal)
+        return cls.from_point_and_normal(
+            reference_point=p1, normal=np.cross(p2 - p1, vector)
+        )
 
     @classmethod
     def fit_from_points(cls, points):
@@ -110,8 +134,8 @@ class Plane(object):
         if direction_decimals is None:
             direction_decimals = self.DEFAULT_DIRECTION_DECIMALS
         return Plane(
-            point_on_plane=np.around(self.reference_point, position_decimals),
-            unit_normal=np.around(self.normal, direction_decimals),
+            reference_point=np.around(self.reference_point, position_decimals),
+            normal=np.around(self.normal, direction_decimals),
         )
 
     def serialize(self, position_decimals=None, direction_decimals=None):
@@ -180,8 +204,8 @@ class Plane(object):
         cls.validate(data)
 
         return cls(
-            point_on_plane=np.array(data["referencePoint"]),
-            unit_normal=np.array(data["unitNormal"]),
+            reference_point=np.array(data["referencePoint"]),
+            normal=np.array(data["unitNormal"]),
         )
 
     @property
@@ -193,18 +217,10 @@ class Plane(object):
 
         defines the plane.
         """
-        A, B, C = self._n
-        D = -self._r0.dot(self._n)
+        A, B, C = self.normal
+        D = -self.reference_point.dot(self.normal)
 
         return np.array([A, B, C, D])
-
-    @property
-    def reference_point(self):
-        """
-        The point used to create this plane.
-
-        """
-        return self._r0
 
     @property
     def canonical_point(self):
@@ -219,21 +235,13 @@ class Plane(object):
         as we do when searching for planar cross sections.
 
         """
-        return self._r0.dot(self._n) * self._n
-
-    @property
-    def normal(self):
-        """
-        Return the plane's normal vector.
-
-        """
-        return self._n
+        return self.reference_point.dot(self.normal) * self.normal
 
     def flipped(self):
         """
         Creates a new Plane with an inverted orientation.
         """
-        return Plane(point_on_plane=self._r0, unit_normal=-self._n)
+        return Plane(reference_point=self.reference_point, normal=-self.normal)
 
     def flipped_if(self, condition):
         """
@@ -426,12 +434,12 @@ class Plane(object):
             angle=angle_between_vectors,
             units="rad",
         )
-        return Plane(point_on_plane=coplanar_point, unit_normal=new_normal)
+        return Plane(reference_point=coplanar_point, normal=new_normal)
 
 
-Plane.xy = Plane(point_on_plane=np.zeros(3), unit_normal=vg.basis.z)
+Plane.xy = Plane(reference_point=np.zeros(3), normal=vg.basis.z)
 Plane.xy.__doc__ = "The `xy`-plane."
-Plane.xz = Plane(point_on_plane=np.zeros(3), unit_normal=vg.basis.y)
+Plane.xz = Plane(reference_point=np.zeros(3), normal=vg.basis.y)
 Plane.xz.__doc__ = "The `xz`-plane."
-Plane.yz = Plane(point_on_plane=np.zeros(3), unit_normal=vg.basis.x)
+Plane.yz = Plane(reference_point=np.zeros(3), normal=vg.basis.x)
 Plane.yz.__doc__ = "The `yz`-plane."

--- a/polliwog/plane/_slicing.py
+++ b/polliwog/plane/_slicing.py
@@ -6,7 +6,7 @@ from ..tri import FACE_DTYPE
 def slice_triangles_by_plane(
     vertices,
     faces,
-    point_on_plane,
+    plane_reference_point,
     plane_normal,
     faces_to_slice=None,
     ret_face_mapping=False,
@@ -24,7 +24,7 @@ def slice_triangles_by_plane(
 
     vg.shape.check(locals(), "vertices", (-1, 3))
     vg.shape.check(locals(), "faces", (-1, 3))
-    vg.shape.check(locals(), "point_on_plane", (3,))
+    vg.shape.check(locals(), "plane_reference_point", (3,))
     vg.shape.check(locals(), "plane_normal", (3,))
     if faces_to_slice is not None:
         vg.shape.check(locals(), "faces_to_slice", (-1,))
@@ -34,7 +34,7 @@ def slice_triangles_by_plane(
         vertices=vertices,
         faces=faces,
         plane_normal=plane_normal,
-        plane_origin=point_on_plane,
+        plane_origin=plane_reference_point,
         face_index=None if faces_to_slice is None else faces_to_slice.nonzero()[0],
         return_face_mapping=ret_face_mapping,
     )

--- a/polliwog/plane/test_functions.py
+++ b/polliwog/plane/test_functions.py
@@ -119,8 +119,8 @@ def test_signed_distances_for_diagonal_plane():
             points=np.array([[425.0, 425.0, 25.0], [-500.0, -500.0, 25.0]]),
             # Diagonal plane @ origin - draw a picture!
             plane_equations=Plane(
-                point_on_plane=np.array([1.0, 1.0, 0.0]),
-                unit_normal=vg.normalize(np.array([1.0, 1.0, 0.0])),
+                reference_point=np.array([1.0, 1.0, 0.0]),
+                normal=vg.normalize(np.array([1.0, 1.0, 0.0])),
             ).equation,
         ),
         np.array(
@@ -144,7 +144,7 @@ def test_project_point_to_plane():
         project_point_to_plane(
             points=np.array([10, 20, -5]),
             plane_equations=Plane(
-                point_on_plane=np.array([0, 10, 0]), unit_normal=vg.basis.y
+                reference_point=np.array([0, 10, 0]), normal=vg.basis.y
             ).equation,
         ),
         np.array([10, 10, -5]),
@@ -156,7 +156,7 @@ def test_project_point_to_plane_vectorized_points():
         project_point_to_plane(
             points=np.array([[10, 20, -5], [2, 7, 203]]),
             plane_equations=Plane(
-                point_on_plane=np.array([0, 10, 0]), unit_normal=vg.basis.y
+                reference_point=np.array([0, 10, 0]), normal=vg.basis.y
             ).equation,
         ),
         np.array([[10, 10, -5], [2, 10, 203]]),
@@ -170,10 +170,10 @@ def test_project_point_to_plane_vectorized_planes():
             plane_equations=np.array(
                 [
                     Plane(
-                        point_on_plane=np.array([0, 10, 0]), unit_normal=vg.basis.y
+                        reference_point=np.array([0, 10, 0]), normal=vg.basis.y
                     ).equation,
                     Plane(
-                        point_on_plane=np.array([0, 10, 0]), unit_normal=vg.basis.y
+                        reference_point=np.array([0, 10, 0]), normal=vg.basis.y
                     ).equation,
                 ]
             ),
@@ -189,10 +189,10 @@ def test_project_point_to_plane_vectorized_both():
             plane_equations=np.array(
                 [
                     Plane(
-                        point_on_plane=np.array([0, 10, 0]), unit_normal=vg.basis.y
+                        reference_point=np.array([0, 10, 0]), normal=vg.basis.y
                     ).equation,
                     Plane(
-                        point_on_plane=np.array([0, 10, 0]), unit_normal=vg.basis.y
+                        reference_point=np.array([0, 10, 0]), normal=vg.basis.y
                     ).equation,
                 ]
             ),
@@ -209,7 +209,7 @@ def test_project_point_to_plane_validation():
         project_point_to_plane(
             points=np.array([[[1.0]]]),
             plane_equations=Plane(
-                point_on_plane=np.array([0, 10, 0]), unit_normal=vg.basis.y
+                reference_point=np.array([0, 10, 0]), normal=vg.basis.y
             ).equation,
         )
 
@@ -222,10 +222,10 @@ def test_project_point_to_plane_validation():
             plane_equations=np.array(
                 [
                     Plane(
-                        point_on_plane=np.array([0, 10, 0]), unit_normal=vg.basis.y
+                        reference_point=np.array([0, 10, 0]), normal=vg.basis.y
                     ).equation,
                     Plane(
-                        point_on_plane=np.array([0, 10, 0]), unit_normal=vg.basis.y
+                        reference_point=np.array([0, 10, 0]), normal=vg.basis.y
                     ).equation,
                 ]
             ),
@@ -237,7 +237,7 @@ def test_mirror_point_across_plane_vectorized_points():
         mirror_point_across_plane(
             points=np.array([[10, 20, -5], [2, 7, 203]]),
             plane_equations=Plane(
-                point_on_plane=np.array([0, 10, 0]), unit_normal=vg.basis.y
+                reference_point=np.array([0, 10, 0]), normal=vg.basis.y
             ).equation,
         ),
         np.array([[10, 0, -5], [2, 13, 203]]),

--- a/polliwog/plane/test_plane_object.py
+++ b/polliwog/plane/test_plane_object.py
@@ -91,7 +91,7 @@ def test_returns_unsigned_distances_for_diagonal_plane_at_origin():
 
 
 def test_signed_distance_validation():
-    plane = Plane(point_on_plane=np.array([0, 10, 0]), unit_normal=vg.basis.y)
+    plane = Plane(reference_point=np.array([0, 10, 0]), normal=vg.basis.y)
 
     with pytest.raises(ValueError):
         plane.signed_distance(np.array([[[1.0]]]))
@@ -223,25 +223,25 @@ def test_canonical_point():
 
 def test_project_point():
     np.testing.assert_array_equal(
-        Plane(
-            point_on_plane=np.array([0, 10, 0]), unit_normal=vg.basis.y
-        ).project_point(np.array([10, 20, -5])),
+        Plane(reference_point=np.array([0, 10, 0]), normal=vg.basis.y).project_point(
+            np.array([10, 20, -5])
+        ),
         np.array([10, 10, -5]),
     )
 
 
 def test_project_point_vectorized():
     np.testing.assert_array_equal(
-        Plane(
-            point_on_plane=np.array([0, 10, 0]), unit_normal=vg.basis.y
-        ).project_point(np.array([[10, 20, -5], [2, 7, 203]])),
+        Plane(reference_point=np.array([0, 10, 0]), normal=vg.basis.y).project_point(
+            np.array([[10, 20, -5], [2, 7, 203]])
+        ),
         np.array([[10, 10, -5], [2, 10, 203]]),
     )
 
 
 def test_mirror_point():
     np.testing.assert_array_equal(
-        Plane(point_on_plane=np.array([0, 10, 0]), unit_normal=vg.basis.y).mirror_point(
+        Plane(reference_point=np.array([0, 10, 0]), normal=vg.basis.y).mirror_point(
             np.array([10, 20, -5])
         ),
         np.array([10, 0, -5]),

--- a/polliwog/plane/test_slicing.py
+++ b/polliwog/plane/test_slicing.py
@@ -48,7 +48,7 @@ def test_slice_cube_corner():
     common_kwargs = dict(
         vertices=cube_vertices,
         faces=cube_faces,
-        point_on_plane=cube_extent - 0.05,
+        plane_reference_point=cube_extent - 0.05,
         plane_normal=np.array([1, 1, 1]),
     )
 
@@ -91,7 +91,7 @@ def test_slice_cube_submesh():
     _, sliced_faces = slice_triangles_by_plane(
         vertices=cube_vertices,
         faces=cube_faces,
-        point_on_plane=cube_extent - 0.05,
+        plane_reference_point=cube_extent - 0.05,
         plane_normal=np.array([1, 1, 1]),
         faces_to_slice=mask,
     )
@@ -107,7 +107,7 @@ def test_slice_cube_top():
     common_kwargs = dict(
         vertices=cube_vertices,
         faces=cube_faces,
-        point_on_plane=cube_extent - 0.05,
+        plane_reference_point=cube_extent - 0.05,
         plane_normal=vg.basis.z,
     )
 
@@ -160,10 +160,10 @@ def test_slice_cube_edge_multiple_planes():
         *slice_triangles_by_plane(
             vertices=cube_vertices,
             faces=cube_faces,
-            point_on_plane=cube_extent - 0.05,
+            plane_reference_point=cube_extent - 0.05,
             plane_normal=vg.basis.z,
         ),
-        point_on_plane=cube_extent - 0.05,
+        plane_reference_point=cube_extent - 0.05,
         plane_normal=vg.basis.y,
     )
 
@@ -178,7 +178,7 @@ def test_slice_cube_all_in_front():
     common_kwargs = dict(
         vertices=cube_vertices,
         faces=cube_faces,
-        point_on_plane=cube_origin,
+        plane_reference_point=cube_origin,
         plane_normal=vg.basis.x,
     )
 
@@ -201,7 +201,7 @@ def test_slice_cube_all_in_back():
     common_kwargs = dict(
         vertices=cube_vertices,
         faces=cube_faces,
-        point_on_plane=cube_origin + 5,
+        plane_reference_point=cube_origin + 5,
         plane_normal=vg.basis.x,
     )
 
@@ -223,7 +223,7 @@ def test_slice_empty():
     common_kwargs = dict(
         vertices=np.zeros((0, 3), dtype=np.float64),
         faces=np.zeros((0, 3), dtype=FACE_DTYPE),
-        point_on_plane=np.zeros(3),
+        plane_reference_point=np.zeros(3),
         plane_normal=vg.basis.x,
     )
 

--- a/polliwog/polyline/test_polyline_object.py
+++ b/polliwog/polyline/test_polyline_object.py
@@ -743,13 +743,13 @@ def test_intersect_plane():
 
     expected = np.array([[1.0, 7.5, 0.0], [0.0, 7.5, 0.0]])
     actual = polyline.intersect_plane(
-        Plane(point_on_plane=np.array([0.0, 7.5, 0.0]), unit_normal=vg.basis.y)
+        Plane(reference_point=np.array([0.0, 7.5, 0.0]), normal=vg.basis.y)
     )
 
     np.testing.assert_array_equal(actual, expected)
 
     intersection_points, edge_indices = polyline.intersect_plane(
-        Plane(point_on_plane=np.array([0.0, 7.5, 0.0]), unit_normal=vg.basis.y),
+        Plane(reference_point=np.array([0.0, 7.5, 0.0]), normal=vg.basis.y),
         ret_edge_indices=True,
     )
     np.testing.assert_array_equal(intersection_points, expected)
@@ -777,7 +777,7 @@ def test_intersect_plane_with_vertex_on_plane():
 
     expected = np.array([[1.0, 7.5, 0.0], [0.0, 7.5, 0.0]])
     actual = polyline.intersect_plane(
-        Plane(point_on_plane=np.array([0.0, 7.5, 0.0]), unit_normal=vg.basis.y)
+        Plane(reference_point=np.array([0.0, 7.5, 0.0]), normal=vg.basis.y)
     )
 
     np.testing.assert_array_equal(actual, expected)
@@ -803,7 +803,7 @@ def test_sliced_by_plane_closed():
         is_closed=False,
     )
     actual = original.sliced_by_plane(
-        Plane(point_on_plane=np.array([0.0, 7.5, 0.0]), unit_normal=vg.basis.y)
+        Plane(reference_point=np.array([0.0, 7.5, 0.0]), normal=vg.basis.y)
     )
 
     np.testing.assert_array_almost_equal(actual.v, expected.v)
@@ -823,7 +823,7 @@ def test_sliced_by_plane_closed():
         is_closed=False,
     )
     actual = original.sliced_by_plane(
-        Plane(point_on_plane=np.array([0.0, 7.5, 0.0]), unit_normal=vg.basis.neg_y)
+        Plane(reference_point=np.array([0.0, 7.5, 0.0]), normal=vg.basis.neg_y)
     )
 
     np.testing.assert_array_almost_equal(actual.v, expected.v)
@@ -837,14 +837,14 @@ def test_sliced_by_plane_closed():
         ValueError, match="Polyline intersects the plane too many times"
     ):
         zigzag.sliced_by_plane(
-            Plane(point_on_plane=np.array([2.5, 0.0, 0.0]), unit_normal=vg.basis.x)
+            Plane(reference_point=np.array([2.5, 0.0, 0.0]), normal=vg.basis.x)
         )
 
     with pytest.raises(
         ValueError, match="Polyline has no vertices in front of the plane"
     ):
         original.sliced_by_plane(
-            Plane(point_on_plane=np.array([10.0, 0.0, 0.0]), unit_normal=vg.basis.x)
+            Plane(reference_point=np.array([10.0, 0.0, 0.0]), normal=vg.basis.x)
         )
 
 
@@ -875,7 +875,7 @@ def test_sliced_by_plane_closed_on_vertex():
         is_closed=False,
     )
     actual = original.sliced_by_plane(
-        Plane(point_on_plane=np.array([0.0, 1.0, 0.0]), unit_normal=vg.basis.y)
+        Plane(reference_point=np.array([0.0, 1.0, 0.0]), normal=vg.basis.y)
     )
     np.testing.assert_array_almost_equal(actual.v, expected.v)
     assert actual.is_closed is False
@@ -887,7 +887,7 @@ def test_sliced_by_plane_closed_one_vertex():
         ValueError, match="Polyline has no vertices in front of the plane"
     ):
         original.sliced_by_plane(
-            Plane(point_on_plane=np.array([0.0, 7.5, 0.0]), unit_normal=vg.basis.y)
+            Plane(reference_point=np.array([0.0, 7.5, 0.0]), normal=vg.basis.y)
         )
 
 
@@ -907,7 +907,7 @@ def test_sliced_by_plane_open():
 
     expected_vs = np.array([[1.0, 7.5, 0.0], [1.0, 8.0, 0.0]])
     actual = original.sliced_by_plane(
-        Plane(point_on_plane=np.array([0.0, 7.5, 0.0]), unit_normal=vg.basis.y)
+        Plane(reference_point=np.array([0.0, 7.5, 0.0]), normal=vg.basis.y)
     )
 
     np.testing.assert_array_almost_equal(actual.v, expected_vs)
@@ -923,7 +923,7 @@ def test_sliced_by_plane_open():
         ]
     )
     actual = original.sliced_by_plane(
-        Plane(point_on_plane=np.array([0.0, 7.5, 0.0]), unit_normal=vg.basis.neg_y)
+        Plane(reference_point=np.array([0.0, 7.5, 0.0]), normal=vg.basis.neg_y)
     )
 
     np.testing.assert_array_almost_equal(actual.v, expected_vs)
@@ -931,13 +931,13 @@ def test_sliced_by_plane_open():
 
     with pytest.raises(ValueError):
         original.sliced_by_plane(
-            Plane(point_on_plane=np.array([0.0, 15.0, 0.0]), unit_normal=vg.basis.neg_y)
+            Plane(reference_point=np.array([0.0, 15.0, 0.0]), normal=vg.basis.neg_y)
         )
 
     actual = original.sliced_by_plane(
         Plane(
-            point_on_plane=np.array([0.5, 0.0, 0.0]),
-            unit_normal=vg.normalize(np.array([1.0, -1.0, 0.0])),
+            reference_point=np.array([0.5, 0.0, 0.0]),
+            normal=vg.normalize(np.array([1.0, -1.0, 0.0])),
         )
     )
     expected_vs = np.array([[0.5, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 0.5, 0.0]])

--- a/polliwog/polyline/test_slice_by_plane.py
+++ b/polliwog/polyline/test_slice_by_plane.py
@@ -6,7 +6,7 @@ from ._slice_by_plane import slice_open_polyline_by_plane
 
 point_on_plane = np.array([1.0, 2.0, 3.0])
 plane_normal = vg.normalize(np.array([3.0, 4.0, 5.0]))
-plane = Plane(point_on_plane=point_on_plane, unit_normal=plane_normal)
+plane = Plane(reference_point=point_on_plane, normal=plane_normal)
 
 
 def rand_nonzero(*shape):


### PR DESCRIPTION
- Match constructor parameters to properties.
- Enforce immutability.
- Do not normalize in the constructor.
    - This enables idempotent serialization and deserialization.