### PR TITLE
Fix bug in `Polyline.with_segments_bisected()`

### DIFF
--- a/polliwog/polyline/_polyline_object.py
+++ b/polliwog/polyline/_polyline_object.py
@@ -416,8 +416,9 @@ class Polyline:
         With `ret_new_indices=True`, also returns the new indices of the
         original vertices and the new indices of the inserted points.
         """
+        geometric_midpoints = np.average(self.segments[segment_indices], axis=1)
         return self.with_insertions(
-            points=np.mean(self.segments[segment_indices], axis=0),
+            points=geometric_midpoints,
             indices=self.e[segment_indices][:, 1],
             ret_new_indices=ret_new_indices,
         )

--- a/polliwog/polyline/test_polyline_object.py
+++ b/polliwog/polyline/test_polyline_object.py
@@ -561,18 +561,19 @@ def test_with_segments_bisected():
                 [1.0, 1.0, 0.0],
                 [1.0, 1.5, 0.0],
                 [1.0, 2.0, 0.0],
+                [1.0, 2.5, 0.0],
                 [1.0, 3.0, 0.0],
             ]
         )
     )
 
-    expected_indices_of_original_vertices = np.array([0, 1, 3, 5, 6])
+    expected_indices_of_original_vertices = np.array([0, 1, 3, 5, 7])
 
     (
         with_segments_bisected,
         indices_of_original_vertices,
         indices_of_inserted_points,
-    ) = original.with_segments_bisected([1, 2], ret_new_indices=True)
+    ) = original.with_segments_bisected([1, 2, 3], ret_new_indices=True)
 
     np.testing.assert_array_almost_equal(with_segments_bisected.v, expected.v)
     np.testing.assert_array_equal(with_segments_bisected.e, expected.e)


### PR DESCRIPTION
This code happened to work when exactly two bisections were being performed, but does not work with any other number of points.